### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,39 @@
-# Azure Storage Blob Upload from a Node.js Web Application using the v10 SDK
+---
+page_type: sample
+languages:
+- javascript
+- nodejs
+products:
+- azure
+- azure-storage
+description: "This sample demonstrates how to use the Azure Storage v12 SDK in the context of an Express application to upload images into Azure Blob Storage."
+---
 
-This sample demonstrates how to use the Azure Storage v10 SDK in the context of an [Express](https://expressjs.com/) application to upload images into Azure Blob Storage.
+# Azure Storage Blob Upload from a Node.js Web Application using the v12 SDK
+
+This sample demonstrates how to use the Azure Storage v12 SDK in the context of an [Express](https://expressjs.com/) application to upload images into Azure Blob Storage.
+
+If you don't have a Microsoft Azure subscription, you can get a free trial account <a href="http://go.microsoft.com/fwlink/?LinkId=330212">here</a>.
 
 ## SDK Versions
 
-You will find the following folders: [storage-blob-upload-from-webapp-node-v10](./storage-blob-upload-from-webapp-node-v10), which references the [@azure/storage-blob version 10.3.0](https://www.npmjs.com/package/@azure/storage-blob/v/10.3.0) of the SDK and [storage-blob-upload-from-webapp-node-v12](./storage-blob-upload-from-webapp-node-v12), which uses the [@azure/storage-blob version 12.0.0](https://www.npmjs.com/package/@azure/storage-blob/v/12.0.0) of the SDK.
+In this sample, you will find the following folders:
+
+* **[storage-blob-upload-from-webapp-node-v10](./storage-blob-upload-from-webapp-node-v10)** - references [Storage Blob SDK v10.3.0](https://www.npmjs.com/package/@azure/storage-blob/v/10.3.0)
+* **[storage-blob-upload-from-webapp-node-v12](./storage-blob-upload-from-webapp-node-v12)** - references [Storage Blob SDK v12.0.0](https://www.npmjs.com/package/@azure/storage-blob/v/12.0.0)
 
 ## Prerequisites
 
 Clone the repository to your machine:
 
 ```bash
-git clone https://github.com/Azure-Samples/storage-blob-upload-from-webapp-node-v10.git
+git clone https://github.com/Azure-Samples/storage-blob-upload-from-webapp-node-v12.git
 ```
 
-Change into the `storage-blob-upload-from-webapp-node-v10-v4` folder:
+Change into the `storage-blob-upload-from-webapp-node-v12` folder:
 
 ```bash
-cd storage-blob-upload-from-webapp-node-v10-v4
+cd storage-blob-upload-from-webapp-node-v12
 ```
 
 Install dependencies via `npm`:
@@ -31,8 +47,6 @@ npm install
 * Create a storage account.
 * Create a container.
 * Upload a stream to [blockblob](https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs).
-
-If you don't have a Microsoft Azure subscription, you can get a free trial account <a href="http://go.microsoft.com/fwlink/?LinkId=330212">here</a>.
 
 ## Adding your storage account name and key
 

--- a/storage-blob-upload-from-webapp-node-v12/.env.example
+++ b/storage-blob-upload-from-webapp-node-v12/.env.example
@@ -1,2 +1,2 @@
-AZURE_STORAGE_ACCOUNT_NAME=<replace with your storage account name>
-AZURE_STORAGE_ACCOUNT_ACCESS_KEY=<replace with your storage account access key>
+AZURE_STORAGE_ACCOUNT_NAME=<Replace With Your Storage Account Name>
+AZURE_STORAGE_ACCOUNT_ACCESS_KEY=<Replace With Your Storage Account Access Key>


### PR DESCRIPTION
Move over this sample to new Azure SDK:
1. Move the original file to storage-blob-upload-from-webapp-node-v10 folder
2. Add folder storage-blob-upload-from-webapp-node-v12 for the sample referenced to the new SDK
3. Add two sections to the readme:
   - Prerequisites which tell user what info we need
   - SDK Versions

**What old sample do** 
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/65018342-71711b00-d95b-11e9-8b64-46846b84b175.png)

**What can be updated to v12:**
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/65030479-39c19d80-d972-11e9-8fc6-d240e87963ae.png)
