### PR TITLE
Move over to new Azure SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,14 @@ urlFragment: stream-blobs-nodejs
 
 # How to stream blobs to Azure Blob Storage with Node.js
 
-This sample demonstrates how to stream blobs to Azure Blob Storage with Node.js.
-
-If you don't have a Microsoft Azure subscription, you can get a [free account] before you begin.
-
 ## SDK Versions
-
 In this sample, you will find the following folders:
 
-* **[azure-sdk-for-js-storage-blob-stream-nodejs-v10]** - references [Storage Blob SDK v10]
-* **[azure-sdk-for-js-storage-blob-stream-nodejs-v12]** - references [Storage Blob SDK v12]
+* **azure-sdk-for-js-storage-blob-stream-nodejs-v10** - references Storage Blob SDK v10
+* **azure-sdk-for-js-storage-blob-stream-nodejs-v12** - references Storage Blob SDK v12
 
 ## Prerequisites
+If you don't have a Microsoft Azure subscription, you can get a [free account] before you begin.
 
 Clone the repository to your machine:
 
@@ -44,17 +40,14 @@ npm install
 ```
 
 ## This Sample shows how to do following operations of Storage Blobs
-
 * Create a storage account.
 * Create a container.
 * Upload a stream to [blockblob].
 
 ## Adding your storage account name and key
-
 Navigate to your storage account in the [Azure Portal] and copy the account name and key (under **Settings** > **Access keys**) into the `.env.example` file. Save the file and then rename it from `.env.example` to `.env`.
 
 ## Running the sample
-
 Start the server:
 
 ```bash
@@ -66,10 +59,6 @@ Navigate to [http://localhost:3000] and upload an image to blob storage.
 You can use the [Azure Storage Explorer] to view blob containers and verify your upload is successful.
 
 <!-- LINKS -->
-[azure-sdk-for-js-storage-blob-stream-nodejs-v10]: https://github.com/Azure-Samples/azure-sdk-for-js-storage-blob-stream-nodejs/tree/master/azure-sdk-for-js-storage-blob-stream-nodejs-v10
-[azure-sdk-for-js-storage-blob-stream-nodejs-v12]: https://github.com/Azure-Samples/azure-sdk-for-js-storage-blob-stream-nodejs/tree/master/azure-sdk-for-js-storage-blob-stream-nodejs-v12
-[Storage Blob SDK v10]: https://www.npmjs.com/package/@azure/storage-blob/v/10.3.0
-[Storage Blob SDK v12]: https://www.npmjs.com/package/@azure/storage-blob/v/12.0.0
 [blockblob]: https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
 [Azure Portal]: https://portal.azure.com
 [http://localhost:3000]: http://localhost:3000


### PR DESCRIPTION
Move over this sample to new Azure SDK:
1. Move the original file to azure-sdk-for-js-storage-blob-stream-nodejs-v10 folder
2. Add folder azure-sdk-for-js-storage-blob-stream-nodejs-v12 for the sample referenced to the new SDK
3. Add three sections to the readme:
   - Prerequisites which tell user what info we need
   - SDK Versions
   - UrlFragment

**What old sample do** 
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/65018342-71711b00-d95b-11e9-8b64-46846b84b175.png)

**What can be updated to v12:**
---------------------------------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/20970631/65030479-39c19d80-d972-11e9-8fc6-d240e87963ae.png)